### PR TITLE
update gradle, optimized android 13 & memperbaiki bug pendingIntent pada android 12+

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="1.8" />
   </component>
 </project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,12 +14,12 @@ plugins {
 }
 
 android {
-    compileSdk 30
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.indraazimi.login"
         minSdk 19
-        targetSdk 30
+        targetSdk 33
         versionCode 1
         versionName "1.0"
         multiDexEnabled true

--- a/app/src/main/java/com/indraazimi/login/notify/AlarmUtils.kt
+++ b/app/src/main/java/com/indraazimi/login/notify/AlarmUtils.kt
@@ -37,8 +37,13 @@ object AlarmUtils {
 
     fun setAlarmOff(context: Context) {
         val intent = Intent(context, ReminderReceiver::class.java)
-        val pendingIntent = PendingIntent.getBroadcast(context, REQUEST_CODE, intent,
-            PendingIntent.FLAG_NO_CREATE)
+        val pendingIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S){
+            PendingIntent.getBroadcast(context, REQUEST_CODE, intent,
+                PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_MUTABLE)
+        } else {
+            PendingIntent.getBroadcast(context, REQUEST_CODE, intent,
+                PendingIntent.FLAG_NO_CREATE)
+        }
         val manager = context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager
         if (pendingIntent != null && manager != null) {
             manager.cancel(pendingIntent)

--- a/app/src/main/java/com/indraazimi/login/notify/AlarmUtils.kt
+++ b/app/src/main/java/com/indraazimi/login/notify/AlarmUtils.kt
@@ -13,6 +13,7 @@ import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import java.util.*
 
 object AlarmUtils {
@@ -21,7 +22,14 @@ object AlarmUtils {
 
     fun setAlarm(context: Context) {
         val intent = Intent(context, ReminderReceiver::class.java)
-        val pendingIntent = PendingIntent.getBroadcast(context, REQUEST_CODE, intent, 0)
+        val pendingIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            PendingIntent.getBroadcast(
+                context, REQUEST_CODE, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+            )
+        } else {
+            PendingIntent.getBroadcast(
+                context, REQUEST_CODE, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+        }
         val manager = context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager
         manager?.setInexactRepeating(AlarmManager.RTC_WAKEUP, getTime(),
             AlarmManager.INTERVAL_HALF_DAY, pendingIntent)

--- a/app/src/main/java/com/indraazimi/login/notify/NotificationUtils.kt
+++ b/app/src/main/java/com/indraazimi/login/notify/NotificationUtils.kt
@@ -24,8 +24,12 @@ private const val NOTIFICATION_ID = 0
 
 fun NotificationManager.sendNotification(context: Context) {
     val intent = Intent(context, MainActivity::class.java)
-    val pendingIntent = PendingIntent.getActivity(context,
-        NOTIFICATION_ID, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+    val pendingIntent = if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S){
+        PendingIntent.getActivity(context, NOTIFICATION_ID, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE)
+    } else {
+        PendingIntent.getActivity(context, NOTIFICATION_ID, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+    }
 
     val builder = NotificationCompat.Builder(
         context,

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.0.2"
+        classpath 'com.android.tools.build:gradle:7.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31"
         classpath 'com.google.gms:google-services:4.3.10'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Oct 03 21:06:10 ICT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
pada android 12 keatas aplikasi tidak bisa dijalankan karena pendingIntent.getBroadcast() sendiri membutuhkan optimasi berupa PendingIntent.FLAG_MUTABLE pada parameter untuk flag, dan mutable ini sudah diwajibkan pada android 12+, pada kode yang saya rubah, disini saya membuat pengecekan ketika pengguna menggunakan android api > 32 maka flag pada pendingIntent.getBroadcast() harus menggunakan PendingIntent.FLAG_MUTABLE.